### PR TITLE
Use the new webpack-4 hooks API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,15 @@
-function NameAllModulesPlugin() {
-}
-
-NameAllModulesPlugin.prototype.apply = function (compiler) {
-    compiler.plugin("compilation", (compilation) => {
-      compilation.plugin("before-module-ids", (modules) => {
-        modules.forEach((module) => {
-          if (module.id !== null) {
-            return;
+class NameAllModulesPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap("NameAllModulesPlugin", compilation => {
+      compilation.hooks.beforeModuleIds.tap("NameAllModulesPlugin", modules => {
+        for (const module of modules) {
+          if (module.id === null) {
+            module.id = module.identifier();
           }
-          module.id = module.identifier();
-        });
+        }
       });
     });
-};
+  }
+}
 
 module.exports = NameAllModulesPlugin;


### PR DESCRIPTION
Fixes webpack-4 deprecation warning

> (node:58346) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead

Also switched to `class` and `for..of` to match updated code style for webpack (see [`NamedModulesPlugin`](https://github.com/webpack/webpack/blob/v4.2.0/lib/NamedModulesPlugin.js))

This API is new to webpack-4, so this is a breaking change.